### PR TITLE
refactor: add the recipientKey in create invitation functionality

### DIFF
--- a/src/events/CredentialEvents.ts
+++ b/src/events/CredentialEvents.ts
@@ -1,3 +1,4 @@
+import type { RestMultiTenantAgentModules } from '../cliAgent'
 import type { ServerConfig } from '../utils/ServerConfig'
 import type { Agent, CredentialStateChangedEvent } from '@credo-ts/core'
 
@@ -6,11 +7,26 @@ import { CredentialEventTypes } from '@credo-ts/core'
 import { sendWebSocketEvent } from './WebSocketEvents'
 import { sendWebhookEvent } from './WebhookEvent'
 
-export const credentialEvents = async (agent: Agent, config: ServerConfig) => {
+export const credentialEvents = async (agent: Agent<RestMultiTenantAgentModules>, config: ServerConfig) => {
   agent.events.on(CredentialEventTypes.CredentialStateChanged, async (event: CredentialStateChangedEvent) => {
     const record = event.payload.credentialRecord
-    const body = { ...record.toJSON(), ...event.metadata }
 
+    const body: Record<string, unknown> = {
+      ...record.toJSON(),
+      ...event.metadata,
+      outOfBandId: null,
+    }
+
+    if (event.metadata.contextCorrelationId !== 'default' && record?.connectionId) {
+      await agent.modules.tenants.withTenantAgent(
+        { tenantId: event.metadata.contextCorrelationId },
+        async (tenantAgent) => {
+          const connectionRecord = await tenantAgent.connections.findById(record.connectionId!)
+
+          body.outOfBandId = connectionRecord?.outOfBandId
+        }
+      )
+    }
     // Only send webhook if webhook url is configured
     if (config.webhookUrl) {
       await sendWebhookEvent(config.webhookUrl + '/credentials', body, agent.config.logger)


### PR DESCRIPTION
### What ###
Addition of the recipient key parameter in the create invitation functionality.

### Why ###
To enable reuse connection functionality.

### How ###

Modify the create invitation function to accept the recipient key as a parameter.