### PR TITLE
Refactor/error handling for multi tenancy controller

### DIFF
--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -1849,6 +1849,7 @@ export class MultiTenancyController extends Controller {
           throw new BadRequestError('Seed is required')
         }
         didCreateResponse = await tenantAgent.dids.create<KeyDidCreateOptions>({
+          //TODO enum for method
           method: 'key',
           options: {
             keyType: KeyType.Ed25519,

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -1354,11 +1354,7 @@ export class MultiTenancyController extends Controller {
 
   @Security('apiKey')
   @Post('/credentials/create-offer/:tenantId')
-  public async createOffer(
-    @Body() createOfferOptions: CreateOfferOptions,
-    @Path('tenantId') tenantId: string,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async createOffer(@Body() createOfferOptions: CreateOfferOptions, @Path('tenantId') tenantId: string) {
     let offer
     try {
       await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
@@ -1372,17 +1368,13 @@ export class MultiTenancyController extends Controller {
 
       return offer
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
   @Security('apiKey')
   @Post('/credentials/create-offer-oob/:tenantId')
-  public async createOfferOob(
-    @Path('tenantId') tenantId: string,
-    @Body() createOfferOptions: CreateOfferOobOptions,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async createOfferOob(@Path('tenantId') tenantId: string, @Body() createOfferOptions: CreateOfferOobOptions) {
     let createOfferOobRecord
 
     try {
@@ -1447,15 +1439,13 @@ export class MultiTenancyController extends Controller {
       })
       return createOfferOobRecord
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
   @Security('apiKey')
   @Post('/credentials/accept-offer/:tenantId')
   public async acceptOffer(
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>,
     @Path('tenantId') tenantId: string,
     @Body() acceptCredentialOfferOptions: AcceptCredentialOfferOptions
   ) {
@@ -1476,13 +1466,7 @@ export class MultiTenancyController extends Controller {
 
       return acceptOffer
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `credential with credential record id "${acceptCredentialOfferOptions.credentialRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -1490,9 +1474,7 @@ export class MultiTenancyController extends Controller {
   @Get('/credentials/:credentialRecordId/:tenantId')
   public async getCredentialById(
     @Path('credentialRecordId') credentialRecordId: RecordId,
-    @Path('tenantId') tenantId: string,
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
+    @Path('tenantId') tenantId: string
   ) {
     let credentialRecord
     try {
@@ -1503,13 +1485,7 @@ export class MultiTenancyController extends Controller {
 
       return credentialRecord
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `credential with credential record id "${credentialRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -1522,39 +1498,42 @@ export class MultiTenancyController extends Controller {
     @Query('state') state?: CredentialState
   ) {
     let credentialRecord
-    await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
-      const credentialRepository = tenantAgent.dependencyManager.resolve(CredentialRepository)
-      const credentials = await credentialRepository.findByQuery(tenantAgent.context, {
-        connectionId,
-        threadId,
-        state,
+    try {
+      await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+        const credentialRepository = tenantAgent.dependencyManager.resolve(CredentialRepository)
+        const credentials = await credentialRepository.findByQuery(tenantAgent.context, {
+          connectionId,
+          threadId,
+          state,
+        })
+        credentialRecord = credentials.map((c: any) => c.toJSON())
       })
-      credentialRecord = credentials.map((c: any) => c.toJSON())
-    })
-    return credentialRecord
+      return credentialRecord
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
   }
 
   @Security('apiKey')
   @Get('/proofs/:tenantId')
   public async getAllProofs(@Path('tenantId') tenantId: string, @Query('threadId') threadId?: string) {
     let proofRecord
-    await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
-      let proofs = await tenantAgent.proofs.getAll()
-      if (threadId) proofs = proofs.filter((p: any) => p.threadId === threadId)
-      proofRecord = proofs.map((proof: any) => proof.toJSON())
-    })
-    return proofRecord
+    try {
+      await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+        let proofs = await tenantAgent.proofs.getAll()
+        if (threadId) proofs = proofs.filter((p: any) => p.threadId === threadId)
+        proofRecord = proofs.map((proof: any) => proof.toJSON())
+      })
+      return proofRecord
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
   }
 
   @Security('apiKey')
   @Get('/form-data/:tenantId/:proofRecordId')
   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-  public async proofFormData(
-    @Path('proofRecordId') proofRecordId: string,
-    @Path('tenantId') tenantId: string,
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async proofFormData(@Path('proofRecordId') proofRecordId: string, @Path('tenantId') tenantId: string) {
     let proof
     try {
       await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
@@ -1562,25 +1541,14 @@ export class MultiTenancyController extends Controller {
       })
       return proof
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `proof with proofRecordId "${proofRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
   @Security('apiKey')
   @Post('/proofs/request-proof/:tenantId')
   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-  public async requestProof(
-    @Body() requestProofOptions: RequestProofOptions,
-    @Path('tenantId') tenantId: string,
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async requestProof(@Body() requestProofOptions: RequestProofOptions, @Path('tenantId') tenantId: string) {
     let proof
     try {
       await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
@@ -1599,7 +1567,7 @@ export class MultiTenancyController extends Controller {
 
       return proof
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -1607,8 +1575,7 @@ export class MultiTenancyController extends Controller {
   @Post('/proofs/create-request-oob/:tenantId')
   public async createRequest(
     @Path('tenantId') tenantId: string,
-    @Body() createRequestOptions: CreateProofRequestOobOptions,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
+    @Body() createRequestOptions: CreateProofRequestOobOptions
   ) {
     let oobProofRecord
     try {
@@ -1675,7 +1642,7 @@ export class MultiTenancyController extends Controller {
 
       return oobProofRecord
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -1686,13 +1653,12 @@ export class MultiTenancyController extends Controller {
     @Path('tenantId') tenantId: string,
     @Path('proofRecordId') proofRecordId: string,
     @Body()
-    request: {
+    request: //TODO type for request
+    {
       filterByPresentationPreview?: boolean
       filterByNonRevocationRequirements?: boolean
       comment?: string
-    },
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
+    }
   ) {
     let proofRecord
     try {
@@ -1700,65 +1666,40 @@ export class MultiTenancyController extends Controller {
         const requestedCredentials = await tenantAgent.proofs.selectCredentialsForRequest({
           proofRecordId,
         })
-
         const acceptProofRequest: AcceptProofRequestOptions = {
           proofRecordId,
           comment: request.comment,
           proofFormats: requestedCredentials.proofFormats,
         }
-
         const proof = await tenantAgent.proofs.acceptRequest(acceptProofRequest)
 
         proofRecord = proof.toJSON()
       })
       return proofRecord
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `proof with proofRecordId "${proofRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
   @Security('apiKey')
   @Post('/proofs/:proofRecordId/accept-presentation/:tenantId')
   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-  public async acceptPresentation(
-    @Path('tenantId') tenantId: string,
-    @Path('proofRecordId') proofRecordId: string,
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async acceptPresentation(@Path('tenantId') tenantId: string, @Path('proofRecordId') proofRecordId: string) {
     let proof
     try {
       await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
         proof = await tenantAgent.proofs.acceptPresentation({ proofRecordId })
       })
-
       return proof
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `proof with proofRecordId "${proofRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
   @Security('apiKey')
   @Get('/proofs/:proofRecordId/:tenantId')
   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-  public async getProofById(
-    @Path('tenantId') tenantId: string,
-    @Path('proofRecordId') proofRecordId: RecordId,
-    @Res() notFoundError: TsoaResponse<404, { reason: string }>,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>
-  ) {
+  public async getProofById(@Path('tenantId') tenantId: string, @Path('proofRecordId') proofRecordId: RecordId) {
     let proofRecord
     try {
       await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
@@ -1767,13 +1708,7 @@ export class MultiTenancyController extends Controller {
       })
       return proofRecord
     } catch (error) {
-      if (error instanceof RecordNotFoundError) {
-        return notFoundError(404, {
-          reason: `proof with proofRecordId "${proofRecordId}" not found.`,
-        })
-      }
-
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -53,7 +53,7 @@ import * as fs from 'fs'
 
 import { CredentialEnum, DidMethod, Network, Role } from '../../enums/enum'
 import ErrorHandlingService from '../../errorHandlingService'
-import { NotFoundError } from '../../errors'
+import { BadRequestError, NotFoundError } from '../../errors'
 import { BCOVRIN_REGISTER_URL, INDICIO_NYM_URL } from '../../utils/util'
 import { SchemaId, CredentialDefinitionId, RecordId, ProofRecordExample, ConnectionRecordExample } from '../examples'
 import {
@@ -1352,8 +1352,6 @@ export class MultiTenancyController extends Controller {
     }
   }
 
-  ////My APIs
-
   @Security('apiKey')
   @Post('/credentials/create-offer/:tenantId')
   public async createOffer(
@@ -1778,7 +1776,7 @@ export class MultiTenancyController extends Controller {
       return internalServerError(500, { message: `something went wrong: ${error}` })
     }
   }
-  //done
+
   @Security('apiKey')
   @Delete(':tenantId')
   public async deleteTenantById(@Path('tenantId') tenantId: string) {
@@ -1800,10 +1798,10 @@ export class MultiTenancyController extends Controller {
           throw Error('Seed is required')
         }
         if (!didOptions.keyType) {
-          throw Error('keyType is required')
+          throw new BadRequestError('keyType is required')
         }
         if (!didOptions.domain) {
-          throw Error('domain is required')
+          throw new BadRequestError('domain is required')
         }
         if (didOptions.keyType !== KeyType.Ed25519 && didOptions.keyType !== KeyType.Bls12381g2) {
           throw Error('Only ed25519 and bls12381g2 key type supported')
@@ -1914,7 +1912,8 @@ export class MultiTenancyController extends Controller {
     @Path('connectionId') connectionId: RecordId,
     @Path('tenantId') tenantId: string,
     @Body()
-    config: {
+    config: //TODO type for config
+    {
       question: string
       validResponses: ValidResponse[]
       detail?: string

--- a/src/controllers/polygon/PolygonController.ts
+++ b/src/controllers/polygon/PolygonController.ts
@@ -3,11 +3,14 @@ import type { SchemaMetadata } from '../types'
 
 import { generateSecp256k1KeyPair } from '@ayanworks/credo-polygon-w3c-module'
 import { DidOperation } from '@ayanworks/credo-polygon-w3c-module/build/ledger'
-import { Agent, CredoError } from '@credo-ts/core'
+import { Agent } from '@credo-ts/core'
 import * as fs from 'fs'
 import { injectable } from 'tsyringe'
 
-import { Route, Tags, Security, Controller, Post, TsoaResponse, Res, Body, Get, Path } from 'tsoa'
+import ErrorHandlingService from '../../errorHandlingService'
+import { BadRequestError, UnprocessableEntityError } from '../../errors'
+
+import { Route, Tags, Security, Controller, Post, Body, Get, Path } from 'tsoa'
 
 @Tags('Polygon')
 @Security('apiKey')
@@ -27,7 +30,7 @@ export class Polygon extends Controller {
    * @returns Secp256k1KeyPair
    */
   @Post('create-keys')
-  public async createKeyPair(@Res() internalServerError: TsoaResponse<500, { message: string }>): Promise<{
+  public async createKeyPair(): Promise<{
     privateKey: string
     publicKeyBase58: string
     address: string
@@ -36,7 +39,7 @@ export class Polygon extends Controller {
       return await generateSecp256k1KeyPair()
     } catch (error) {
       // Handle the error here
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -52,16 +55,12 @@ export class Polygon extends Controller {
       did: string
       schemaName: string
       schema: { [key: string]: any }
-    },
-    @Res() internalServerError: TsoaResponse<500, { message: string }>,
-    @Res() badRequestError: TsoaResponse<400, { reason: string }>
+    }
   ): Promise<unknown> {
     try {
       const { did, schemaName, schema } = createSchemaRequest
       if (!did || !schemaName || !schema) {
-        return badRequestError(400, {
-          reason: `One or more parameters are empty or undefined.`,
-        })
+        throw new BadRequestError('One or more parameters are empty or undefined.')
       }
 
       const schemaResponse = await this.agent.modules.polygon.createSchema({
@@ -72,7 +71,9 @@ export class Polygon extends Controller {
       if (schemaResponse.schemaState?.state === 'failed') {
         const reason = schemaResponse.schemaState?.reason?.toLowerCase()
         if (reason && reason.includes('insufficient') && reason.includes('funds')) {
-          throw new Error('Insufficient funds to the address, Please add funds to perform this operation')
+          throw new UnprocessableEntityError(
+            'Insufficient funds to the address, Please add funds to perform this operation'
+          )
         } else {
           throw new Error(schemaResponse.schemaState?.reason)
         }
@@ -84,7 +85,7 @@ export class Polygon extends Controller {
       }
 
       if (!schemaResponse?.schemaId) {
-        throw new Error('Invalid schema response')
+        throw new BadRequestError('Invalid schema response')
       }
       const schemaPayload: SchemaMetadata = {
         schemaUrl: configJson.schemaFileServerURL + schemaResponse?.schemaId,
@@ -94,7 +95,7 @@ export class Polygon extends Controller {
       }
       return schemaPayload
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -109,17 +110,13 @@ export class Polygon extends Controller {
     estimateTransactionRequest: {
       operation: any
       transaction: any
-    },
-    @Res() internalServerError: TsoaResponse<500, { message: string }>,
-    @Res() badRequestError: TsoaResponse<400, { reason: string }>
+    }
   ): Promise<unknown> {
     try {
       const { operation } = estimateTransactionRequest
 
       if (!(operation in DidOperation)) {
-        return badRequestError(400, {
-          reason: `Invalid method parameter!`,
-        })
+        throw new BadRequestError('Invalid method parameter!')
       }
       if (operation === DidOperation.Create) {
         return this.agent.modules.polygon.estimateFeeForDidOperation({ operation })
@@ -127,7 +124,7 @@ export class Polygon extends Controller {
         return this.agent.modules.polygon.estimateFeeForDidOperation({ operation })
       }
     } catch (error) {
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 
@@ -137,23 +134,11 @@ export class Polygon extends Controller {
    * @returns Schema Object
    */
   @Get(':did/:schemaId')
-  public async getSchemaById(
-    @Path('did') did: string,
-    @Path('schemaId') schemaId: string,
-    @Res() internalServerError: TsoaResponse<500, { message: string }>,
-    @Res() forbiddenError: TsoaResponse<401, { reason: string }>
-  ): Promise<unknown> {
+  public async getSchemaById(@Path('did') did: string, @Path('schemaId') schemaId: string): Promise<unknown> {
     try {
       return this.agent.modules.polygon.getSchemaById(did, schemaId)
     } catch (error) {
-      if (error instanceof CredoError) {
-        if (error.message.includes('UnauthorizedClientRequest')) {
-          return forbiddenError(401, {
-            reason: 'this action is not allowed.',
-          })
-        }
-      }
-      return internalServerError(500, { message: `something went wrong: ${error}` })
+      throw ErrorHandlingService.handle(error)
     }
   }
 }


### PR DESCRIPTION
### What

Improved error handling for multi tenancy controller

- POST [/multi-tenancy/credentials/create-offer/{tenantId}]
- POST [/multi-tenancy/credentials/create-offer-oob/{tenantId}]
- POST [/multi-tenancy/credentials/accept-offer/{tenantId}]
- GET [/multi-tenancy/credentials/{credentialRecordId}/{tenantId}]
- GET [/multi-tenancy/credentials/{tenantId}]
- GET [/multi-tenancy/proofs/{tenantId}]
- GET [/multi-tenancy/form-data/{tenantId}/{proofRecordId}]
- POST [/multi-tenancy/proofs/request-proof/{tenantId}]
- POST [/multi-tenancy/proofs/create-request-oob/{tenantId}]
- POST [/multi-tenancy/proofs/{proofRecordId}/accept-request/{tenantId}]
- POST [/multi-tenancy/proofs/{proofRecordId}/accept-presentation/{tenantId}]
- GET [/multi-tenancy/proofs/{proofRecordId}/{tenantId}]

