### PR TITLE
fix: w3c issuance without holderDID

### DIFF
--- a/patches/@credo-ts+core+0.5.3+006+w3c-issuance-without-holder-did-negotiaton.patch
+++ b/patches/@credo-ts+core+0.5.3+006+w3c-issuance-without-holder-did-negotiaton.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/@credo-ts/core/build/modules/credentials/protocol/v2/V2CredentialProtocol.js b/node_modules/@credo-ts/core/build/modules/credentials/protocol/v2/V2CredentialProtocol.js
-index fb1fb9d..260fe21 100644
+index fb1fb9d..b519694 100644
 --- a/node_modules/@credo-ts/core/build/modules/credentials/protocol/v2/V2CredentialProtocol.js
 +++ b/node_modules/@credo-ts/core/build/modules/credentials/protocol/v2/V2CredentialProtocol.js
-@@ -444,6 +444,7 @@ class V2CredentialProtocol extends BaseCredentialProtocol_1.BaseCredentialProtoc
+@@ -97,7 +97,6 @@ class V2CredentialProtocol extends BaseCredentialProtocol_1.BaseCredentialProtoc
          let credentialRecord = await this.findByProperties(messageContext.agentContext, {
-             threadId: requestMessage.threadId,
+             threadId: proposalMessage.threadId,
              role: models_1.CredentialRole.Issuer,
-+            connectionId: connection?.id
+-            connectionId: connection === null || connection === void 0 ? void 0 : connection.id,
          });
-         const formatServices = this.getFormatServicesFromMessage(requestMessage.formats);
+         const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats);
          if (formatServices.length === 0) {


### PR DESCRIPTION
# What:
- Search for credential proposals using threadId only. 
- Allows issuance flow of w3c credential formats without holderDID

# Why
- Avoid searching for credential proposal record without connectionId, as this caused issues while negotiating proposal from holder side