### PR TITLE
refactor: replace the bcovrin network url

### DIFF
--- a/samples/cliConfig.json
+++ b/samples/cliConfig.json
@@ -19,7 +19,7 @@
       "indyNamespace": "indicio:demonet"
     },
     {
-      "genesisTransactions": "http://test.bcovrin.vonx.io/genesis",
+      "genesisTransactions": "https://raw.githubusercontent.com/bcgov/von-network/main/BCovrin/genesis_test",
       "indyNamespace": "bcovrin:testnet"
     }
   ],


### PR DESCRIPTION
### What ###
Replaced the existing bcovrin network URL with the new URL.
### Why ###
The old URL is connect disconnet, and the new network URL needs to be used to ensure proper connectivity and functionality with the bcovrin network.
### How ###
Updated the URL in the relevant configuration files and code sections where the bcovrin network URL is referenced.
