### PR TITLE
fix: added goal code to outofBandRecord in the proof controller

### DIFF
--- a/src/controllers/proofs/ProofController.ts
+++ b/src/controllers/proofs/ProofController.ts
@@ -188,6 +188,7 @@ export class ProofController extends Controller {
         messages: [proofMessage],
         autoAcceptConnection: true,
         imageUrl: createRequestOptions?.imageUrl,
+        goalCode: createRequestOptions?.goalCode,
         invitationDid,
       })
 

--- a/src/events/ProofEvents.ts
+++ b/src/events/ProofEvents.ts
@@ -10,7 +10,7 @@ export const proofEvents = async (agent: Agent, config: ServerConfig) => {
   agent.events.on(ProofEventTypes.ProofStateChanged, async (event: ProofStateChangedEvent) => {
     const record = event.payload.proofRecord
     const body = { ...record.toJSON(), ...event.metadata } as { proofData?: any }
-    if (event.metadata.contextCorrelationId !== 'default' && record.state === 'done') {
+    if (event.metadata.contextCorrelationId !== 'default') {
       const tenantAgent = await agent.modules.tenants.getTenantAgent({
         tenantId: event.metadata.contextCorrelationId,
       })


### PR DESCRIPTION
### What?
- Added goal code to `outofBandRecord` in the proof controller.
- Updated the binding proof data condition for the shared agent.

### Why?
- To ensure response consistency.