### PR TITLE
fix: Non wallet badge issuance error due to datatype check on api

### DIFF
--- a/src/controllers/agent/AgentController.ts
+++ b/src/controllers/agent/AgentController.ts
@@ -118,7 +118,7 @@ export class AgentController extends Controller {
     @Request() request: Req,
     @Query('storeCredential') storeCredential: boolean,
     @Query('dataTypeToSign') dataTypeToSign: 'rawData' | 'jsonLd',
-    @Body() data: CustomW3cJsonLdSignCredentialOptions | SignDataOptions,
+    @Body() data: CustomW3cJsonLdSignCredentialOptions | SignDataOptions | any,
   ) {
     try {
       // JSON-LD VC Signing


### PR DESCRIPTION
# What

- Non wallet badge issuance error during sign operation due to datatype check on api